### PR TITLE
Trigger CI on tag pushes so deploydocs publishes versioned docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags: ['*']
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExperienceAnalysis"
 uuid = "51cd30ab-a913-41ff-9b6f-9b78880a2ac2"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary

The CI workflow only triggers on master pushes and PRs, never on tag pushes. When TagBot creates a release tag, no CI run fires against the tag, so \`deploydocs\` never publishes the versioned \`/vX.Y.Z/\` directory and the \`stable\` symlink never advances.

As a result, \`https://docs.juliaactuary.org/ExperienceAnalysis/stable/\` currently returns **404** — no versioned dir has ever been deployed, despite v2.0.1 being tagged on 2026-02-16. Only \`/dev/\` exists.

Adding \`tags: ['*']\` makes the next tag trigger a docs build that publishes the corresponding versioned dir and creates the \`stable\` symlink. This matches the standard Documenter recommendation and the existing config in \`FinanceCore.jl\`, \`EconomicScenarioGenerators.jl\`, and \`TermLife.jl\`.

## Test plan

- [ ] PR CI passes (same as today's master CI behavior)
- [ ] After merge + next tag, confirm a \`/vX.Y.Z/\` directory appears under \`docs.juliaactuary.org/ExperienceAnalysis/\` and \`/stable/\` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)